### PR TITLE
feat: 후속기사 알림 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,13 +29,13 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+    implementation("com.google.firebase:firebase-admin:9.5.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-
 }
 
 kotlin {

--- a/src/main/kotlin/com/flownews/api/push/api/PushMessageSendApi.kt
+++ b/src/main/kotlin/com/flownews/api/push/api/PushMessageSendApi.kt
@@ -1,0 +1,23 @@
+package com.flownews.api.push.api
+
+import com.flownews.api.common.api.ApiResponse
+import com.flownews.api.common.app.NoDataException
+import com.flownews.api.push.app.PushMessageSender
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class PushMessageSendApi(private val pushMessageSender: PushMessageSender) {
+
+    @PostMapping("/notifications/push", params = ["by=topic"])
+    fun sendPushMessageByTopic(@RequestBody req: PushMessageSendRequest): ApiResponse<out Any?> {
+        return try {
+            ApiResponse.ok(pushMessageSender.sendPushMessages(req.topicId))
+        } catch (e: NoDataException) {
+            ApiResponse.badRequest(e.message)
+        }
+    }
+}
+
+data class PushMessageSendRequest(val topicId: Long)

--- a/src/main/kotlin/com/flownews/api/push/app/PushMessageSender.kt
+++ b/src/main/kotlin/com/flownews/api/push/app/PushMessageSender.kt
@@ -1,0 +1,60 @@
+package com.flownews.api.push.app
+
+import com.flownews.api.push.domain.PushLog
+import com.flownews.api.push.domain.PushLogRepository
+import com.flownews.api.push.domain.PushMessage
+import com.flownews.api.topic.app.TopicSubscriberQueryService
+import com.flownews.api.topic.domain.Topic
+import com.flownews.api.user.domain.Visitor
+import org.springframework.stereotype.Service
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+
+@Service
+class PushMessageSender(
+    private val topicSubscriberQueryService: TopicSubscriberQueryService,
+    private val pushLogRepository: PushLogRepository
+) {
+
+    fun sendPushMessages(topicId: Long) {
+        val topicWithSubscribers = topicSubscriberQueryService.getTopicWithSubscribers(topicId)
+        val topic = topicWithSubscribers.topic
+        val subscribers = topicWithSubscribers.subscribers
+        val messages = subscribers.map { createFrom(topic, it) }
+
+        sendPushMessagesInternal(messages)
+        appendPushLog(messages)
+    }
+
+    //FIXME Firebase 코드 이동 필요
+    private fun sendPushMessagesInternal(messages: List<PushMessage>) {
+        val messages = messages
+            .map { it ->
+                Message.builder()
+                    .setToken(it.deviceToken)
+                    .putData("title", it.title)
+                    .putData("body", it.content)
+                    .putData("image", it.imageUrl)
+                    .putData("topicId", it.topicId.toString())
+                    .build()
+            }
+
+        FirebaseMessaging.getInstance().sendEach(messages)
+    }
+
+    private fun createFrom(topic: Topic, subscriber: Visitor): PushMessage {
+        return PushMessage(
+            deviceToken = subscriber.token!!,
+            title = "새로운 후속기사가 도착했어요",
+            content = "${topic.title}의 후속기사를 보려면 클릭",
+            imageUrl = topic.imageUrl,
+            topicId = topic.id!!,
+            userId = TODO()
+        )
+    }
+
+    private fun appendPushLog(messages: List<PushMessage>) {
+        val logs = messages.map { it -> PushLog(it) }
+        pushLogRepository.saveAll(logs)
+    }
+}

--- a/src/main/kotlin/com/flownews/api/push/domain/PushLog.kt
+++ b/src/main/kotlin/com/flownews/api/push/domain/PushLog.kt
@@ -1,0 +1,40 @@
+package com.flownews.api.push.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+import com.flownews.api.topic.domain.Topic
+import com.flownews.api.user.domain.Visitor
+
+@Entity
+@Table(name = "push_logs")
+data class PushLog(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "device_token")
+    val token: String,
+
+    @Column(name = "message_title")
+    val messageTitle: String,
+
+    @Column(name = "message_body")
+    val messageBody: String,
+
+    @Column(name = "message_image_url")
+    val messageImageUrl: String? = null,
+
+    @Column(name = "sent_at")
+    val sentAt: LocalDateTime = LocalDateTime.now()
+) {
+    constructor(message: PushMessage) : this(
+        userId = message.userId,
+        token = message.deviceToken,
+        messageTitle = message.title,
+        messageBody = message.content,
+        messageImageUrl = message.imageUrl
+    )
+}

--- a/src/main/kotlin/com/flownews/api/push/domain/PushLogRepository.kt
+++ b/src/main/kotlin/com/flownews/api/push/domain/PushLogRepository.kt
@@ -1,0 +1,8 @@
+package com.flownews.api.push.domain
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PushLogRepository : CrudRepository<PushLog, Long> {
+}

--- a/src/main/kotlin/com/flownews/api/push/domain/PushMessage.kt
+++ b/src/main/kotlin/com/flownews/api/push/domain/PushMessage.kt
@@ -1,0 +1,10 @@
+package com.flownews.api.push.domain
+
+data class PushMessage(
+    val topicId: Long,
+    val userId: Long,
+    val deviceToken: String,
+    val title: String,
+    val content: String,
+    val imageUrl: String? = null,
+)

--- a/src/main/kotlin/com/flownews/api/topic/app/TopicSubscribeService.kt
+++ b/src/main/kotlin/com/flownews/api/topic/app/TopicSubscribeService.kt
@@ -39,7 +39,7 @@ class TopicSubscribeService(
     }
 
     private fun saveSubscription(visitor: Visitor, topic: Topic) {
-        topicSubscriptionRepository.save(TopicSubscription(visitorId = visitor.id!!, topic = topic))
+        topicSubscriptionRepository.save(TopicSubscription(visitor = visitor, topic = topic))
     }
 
     private fun getTopic(topicId: Long): Topic {

--- a/src/main/kotlin/com/flownews/api/topic/app/TopicSubscriberQueryService.kt
+++ b/src/main/kotlin/com/flownews/api/topic/app/TopicSubscriberQueryService.kt
@@ -1,0 +1,20 @@
+package com.flownews.api.topic.app
+
+import com.flownews.api.common.app.NoDataException
+import com.flownews.api.topic.domain.TopicRepository
+import com.flownews.api.topic.domain.TopicSubscriptionRepository
+import org.springframework.stereotype.Service
+
+@Service
+class TopicSubscriberQueryService(
+    private val topicRepository: TopicRepository,
+    private val topicSubscriptionRepository: TopicSubscriptionRepository
+) {
+    fun getTopicWithSubscribers(id: Long): TopicWithSubscribers {
+        val topic = topicRepository.findById(id).orElseThrow { NoDataException("topic not found : $id") }
+        val subscriptions = topicSubscriptionRepository.findByTopicId(id)
+        val subscribers = subscriptions.map { it.visitor }
+
+        return TopicWithSubscribers(topic, subscribers)
+    }
+}

--- a/src/main/kotlin/com/flownews/api/topic/app/TopicWithSubscribers.kt
+++ b/src/main/kotlin/com/flownews/api/topic/app/TopicWithSubscribers.kt
@@ -1,0 +1,9 @@
+package com.flownews.api.topic.app
+
+import com.flownews.api.topic.domain.Topic
+import com.flownews.api.user.domain.Visitor
+
+data class TopicWithSubscribers(
+    val topic: Topic,
+    val subscribers: List<Visitor>
+)

--- a/src/main/kotlin/com/flownews/api/topic/domain/TopicSubscription.kt
+++ b/src/main/kotlin/com/flownews/api/topic/domain/TopicSubscription.kt
@@ -1,6 +1,7 @@
 package com.flownews.api.topic.domain
 
 import BaseEntity
+import com.flownews.api.user.domain.Visitor
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -19,9 +20,9 @@ import java.util.UUID
 @Table(name = "subscriptions")
 class TopicSubscription(
     @Id
-    @Column(name = "visitor_id")
-    @JdbcTypeCode(SqlTypes.CHAR)
-    var visitorId: UUID,
+    @ManyToOne
+    @JoinColumn(name = "visitor_id", referencedColumnName = "id")
+    var visitor: Visitor,
 
     @Id
     @ManyToOne

--- a/src/main/kotlin/com/flownews/api/topic/domain/TopicSubscriptionId.kt
+++ b/src/main/kotlin/com/flownews/api/topic/domain/TopicSubscriptionId.kt
@@ -1,11 +1,14 @@
 package com.flownews.api.topic.domain
 
 import jakarta.persistence.Embeddable
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import java.io.Serializable
 import java.util.UUID
 
 @Embeddable
 data class TopicSubscriptionId(
-    val visitorId: UUID,
+    @JdbcTypeCode(SqlTypes.CHAR)
+    val visitor: UUID,
     val topic: Long
 ) : Serializable

--- a/src/main/kotlin/com/flownews/api/topic/domain/TopicSubscriptionRepository.kt
+++ b/src/main/kotlin/com/flownews/api/topic/domain/TopicSubscriptionRepository.kt
@@ -1,7 +1,13 @@
 package com.flownews.api.topic.domain
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
-interface TopicSubscriptionRepository : CrudRepository<TopicSubscription, TopicSubscriptionId>
+interface TopicSubscriptionRepository : CrudRepository<TopicSubscription, TopicSubscriptionId> {
+    @EntityGraph(attributePaths = ["visitor"])
+    fun findByTopicId(@Param("topicId") topicId: Long): List<TopicSubscription>
+
+}

--- a/src/main/kotlin/com/flownews/config/FirebaseConfig.kt
+++ b/src/main/kotlin/com/flownews/config/FirebaseConfig.kt
@@ -1,0 +1,28 @@
+package com.flownews.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+import javax.annotation.PostConstruct
+
+@Configuration
+class FirebaseConfig {
+    private val logger = LoggerFactory.getLogger(FirebaseConfig::class.java)
+
+    @PostConstruct
+    fun initFirebase() {
+        val resource = ClassPathResource("serviceAccountKey.json")
+        if (!resource.exists()) {
+            logger.warn("Firebase service account file not found in classpath")
+            return
+        }
+        val options = FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.fromStream(resource.inputStream))
+            .build()
+        FirebaseApp.initializeApp(options)
+        logger.info("FirebaseApp initialized successfully.")
+    }
+}


### PR DESCRIPTION
다음과 같은 변경사항을 포함합니다.
- `@EntityGraph`를 이용하여 연관 엔티티 한번에 조회
- Firebase SDK 설정 추가
- Firebase SDK를 통해 메시지 전송
- 구독자별 푸시 전송 로그 기록

추후 작업
- Firebase SDK 호출 로직 infra로 리팩토링 필요
- TODO() 확인하여 비회원 UUID 대신 사용자 ID로 변경 필요