### PR TITLE
[SCRUM-182] fix: 사용자 이벤트 로그 IP 주소 오류

### DIFF
--- a/src/main/kotlin/com/flownews/api/logs/api/UserEventLogApi.kt
+++ b/src/main/kotlin/com/flownews/api/logs/api/UserEventLogApi.kt
@@ -3,6 +3,7 @@ package com.flownews.api.logs.api
 import com.flownews.api.logs.domain.UserEventLog
 import com.flownews.api.logs.domain.UserEventLogger
 import com.flownews.api.logs.domain.enums.UserEventType
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.bind.annotation.*
 import org.springframework.http.ResponseEntity
 
@@ -13,13 +14,14 @@ class UserEventLogApi(private val userEventLogger: UserEventLogger) {
     @PostMapping("/logs/{eventType}")
     fun appendEventLog(
         @PathVariable eventType: String,
-        @RequestBody req: Map<String, Any>
+        @RequestBody req: Map<String, Any>,
+        request: HttpServletRequest
     ): ResponseEntity<Void> {
         val type = UserEventType.fromCode(eventType)
 
         val log = UserEventLog(
             eventType = type,
-            ipAddress = req["ipAddress"] as? String ?: "unknown",
+            ipAddress = request.remoteAddr,
             param = extractLog(type, req)
         )
 

--- a/src/main/kotlin/com/flownews/api/topic/api/TopicHistoryRecordApi.kt
+++ b/src/main/kotlin/com/flownews/api/topic/api/TopicHistoryRecordApi.kt
@@ -3,6 +3,7 @@ package com.flownews.api.topic.api
 import com.flownews.api.topic.app.TopicHistoryRecordRequest
 import com.flownews.api.topic.app.TopicHistoryRecordService
 import com.flownews.api.user.app.CustomOAuth2User
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,10 +18,11 @@ class TopicHistoryRecordApi(private val topicHistoryRecordService: TopicHistoryR
     fun recordTopicHistory(
         @PathVariable topicId: Long,
         @AuthenticationPrincipal user: CustomOAuth2User?,
-        @RequestBody req: TopicHistoryRecordRequest
+        @RequestBody req: TopicHistoryRecordRequest,
+        request: HttpServletRequest
     ): ResponseEntity<Void> {
 
-        topicHistoryRecordService.recordHistory(req.withTopic(topicId), user)
+        topicHistoryRecordService.recordHistory(req.with(topicId, request.remoteAddr), user)
 
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/com/flownews/api/topic/app/TopicHistoryRecordRequest.kt
+++ b/src/main/kotlin/com/flownews/api/topic/app/TopicHistoryRecordRequest.kt
@@ -7,5 +7,5 @@ data class TopicHistoryRecordRequest(
     val elapsedTime: Int,
     val direction: String
 ) {
-    fun withTopic(topicId: Long): TopicHistoryRecordRequest = this.copy(topicId = topicId)
+    fun with(topicId: Long, ipAddress: String): TopicHistoryRecordRequest = this.copy(topicId = topicId, ipAddress = ipAddress)
 }


### PR DESCRIPTION
다음과 같은 변경사항을 포함합니다
- 스와이프 이벤트시, IP 주소에 상관없이 127.0.0.1로 저장되는 이슈 수정
- 클라이언트에서 값 받지않고 서버에서 가져오는 것으로 변경
