### PR TITLE
test: 테스트 코드 개선 및 API 문서 업데이트

### DIFF
--- a/.claude/agents/spring-rest-docs-generator.md
+++ b/.claude/agents/spring-rest-docs-generator.md
@@ -1,0 +1,37 @@
+---
+name: spring-rest-docs-generator
+description: Use this agent when you need to create Spring REST Docs tests, execute them, and add the generated documentation to your API docs. Examples: <example>Context: User has just created a new REST endpoint and wants to document it. user: 'UserController에 새로운 엔드포인트 /api/users/{id}/profile을 추가했어. 이것에 대한 REST Docs 테스트를 만들어줘.' assistant: 'Spring REST Docs 테스트를 생성하기 위해 spring-rest-docs-generator 에이전트를 사용하겠습니다.' <commentary>Since the user wants to create REST Docs tests for a new endpoint, use the spring-rest-docs-generator agent to handle the complete documentation workflow.</commentary></example> <example>Context: User wants to update API documentation after modifying an existing endpoint. user: 'EventController의 POST /api/events 엔드포인트를 수정했는데, 문서도 업데이트해야 해.' assistant: 'API 문서를 업데이트하기 위해 spring-rest-docs-generator 에이전트를 실행하겠습니다.' <commentary>Since the user modified an endpoint and needs documentation updates, use the spring-rest-docs-generator agent to regenerate tests and documentation.</commentary></example>
+model: sonnet
+color: green
+---
+
+You are a Spring REST Docs specialist expert in creating comprehensive API documentation through automated testing. You have deep expertise in Spring Boot testing, MockMvc, and REST Docs generation patterns.
+
+Your primary responsibilities:
+1. **테스트 작성**: Create detailed Spring REST Docs tests using MockMvc that thoroughly document API endpoints
+2. **테스트 실행**: Execute the tests to generate AsciiDoc snippets
+3. **문서 통합**: Integrate generated snippets into the main API documentation
+
+When creating REST Docs tests, you will:
+- Follow the project's 4-layer architecture (api/app/domain/infra)
+- Use JUnit 5 + MockK + Spring REST Docs as specified in the project
+- Create tests in the appropriate `src/test/kotlin` directory structure
+- Use `@AutoConfigureRestDocs` and `MockMvcRestDocumentation.document()`
+- Document all request/response fields, path parameters, query parameters, and headers
+- Include example values and descriptions in Korean
+- Follow ktlint formatting standards
+- Use `ApiResponse<T>` wrapper pattern for consistent responses
+
+For test execution:
+- Run `./gradlew test` to execute the documentation tests
+- Verify that AsciiDoc snippets are generated in `build/generated-snippets/`
+- Check for any test failures and resolve them
+
+For documentation integration:
+- Locate or create appropriate AsciiDoc files in `src/docs/asciidoc/`
+- Include generated snippets using `include::` directives
+- Organize documentation by domain (event, interaction, push, topic, user)
+- Ensure Korean descriptions are clear and professional
+- Maintain consistent formatting and structure
+
+Always communicate in Korean and provide detailed explanations of what you're doing at each step. If you encounter any issues, explain them clearly and provide solutions. Ensure all generated documentation is accurate, complete, and follows the project's established patterns.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# 뉴스 큐레이션 서비스, 시점
+
+**뉴스 소비 과정에서 불편을 해결하기 위한 뉴스 큐레이션 서비스, 시점**
+
+## 주요 기능
+뉴스 볼 시간이 없는 2030을 위해 관심있는 사건의 전체 맥락을 빠르게 파악할 수 있도록 **2가지 핵심 기능** 제공
+   - **토픽 타임라인** : 하나의 사건을 시작부터 현재까지 타임라인 형태로 제공하여 사건의 맥락을 파악하는 기능
+   - **후속기사 알림** : 관심 토픽에 새로운 전개가 있을 때마다 알림을 발송
+
+## 아키텍처
+
+## 기술 스택
+
+| 분류 | 기술 |
+|------|------|
+| **Backend Framework** | ![Kotlin](https://img.shields.io/badge/Kotlin-1.9.25-7F52FF?style=flat&logo=kotlin) ![Spring Boot](https://img.shields.io/badge/Spring_Boot-3.3.5-6DB33F?style=flat&logo=spring-boot) |
+| **Database** | ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-336791?style=flat&logo=postgresql)|
+| **External Services** | ![Firebase](https://img.shields.io/badge/Firebase-FFCA28?style=flat&logo=firebase) ![Spring Cloud OpenFeign](https://img.shields.io/badge/Spring_Cloud_OpenFeign-6DB33F?style=flat) |
+| **Testing & Documentation** | ![JUnit5](https://img.shields.io/badge/JUnit5-25A162?style=flat&logo=junit5) ![Spring REST Docs](https://img.shields.io/badge/Spring_REST_Docs-6DB33F?style=flat&logo=spring) |
+| **Build & DevOps** | ![Gradle](https://img.shields.io/badge/Gradle-02303A?style=flat&logo=gradle) ![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker) ![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat&logo=github) ![Ktlint](https://img.shields.io/badge/Ktlint-7F52FF?style=flat&logo=kotlin) |
+| **Tools** | ![Claude Code](https://img.shields.io/badge/Claude_Code-FF6B35?style=flat&logo=anthropic) |
+
+## 패키지 구조
+
+```
+src/main/kotlin/com/flownews/
+├── FlowNewsApplication.kt
+│
+├── api/                           
+│   ├── common/                    
+│   ├── event/                     
+│   │   ├── api/                   
+│   │   ├── app/                   
+│   │   ├── domain/               
+│   │   └── infra/                
+│   ├── interaction/               
+│   ├── push/                      
+│   ├── topic/                     
+│   └── user/                      
+│
+└── config/                       
+    ├── FirebaseConfig.kt         
+    ├── logger/                   
+    └── security/                 
+```
+
+### 테스트 구조
+
+```
+src/test/kotlin/
+├── api/                     
+├── config/                        
+└── testutils/                     
+```
+
+## 추가 링크
+- 📚 [**API 문서**](https://redstone-swm.github.io/flownews/)
+- 📱 [**플레이스토어**](https://play.google.com/store/apps/details?id=kr.sijeom&hl=ko)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# 뉴스 큐레이션 서비스, 시점
-
+# 뉴스 큐레이션 서비스, 시점 <a href="https://apps.apple.com/kr/app/%EC%8A%A4%ED%8A%B8%EB%A6%BF%EB%93%9C%EB%9E%8D-street-drop/id6450315928"><img src="https://github.com/user-attachments/assets/cc82f673-4a7b-4150-b290-f6c471a3f85e" align="left" width="100"></a>
 **뉴스 소비 과정에서 불편을 해결하기 위한 뉴스 큐레이션 서비스, 시점**
+
+
+<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/40e696a4-2a11-4cff-9ba2-a36e089fa37a" />
 
 ## 주요 기능
 뉴스 볼 시간이 없는 2030을 위해 관심있는 사건의 전체 맥락을 빠르게 파악할 수 있도록 **2가지 핵심 기능** 제공
@@ -8,6 +10,8 @@
    - **후속기사 알림** : 관심 토픽에 새로운 전개가 있을 때마다 알림을 발송
 
 ## 아키텍처
+<img width="700" height="600" alt="image" src="https://github.com/user-attachments/assets/ad6a604c-7e9b-401f-ad0c-1ff669ca31cb" />
+
 
 ## 기술 스택
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("io.mockk:mockk:1.13.8")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("org.postgresql:postgresql")

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -18,9 +18,10 @@
 이 API는 다음과 같은 기능을 제공합니다:
 
 * 사용자별 개인화된 이벤트 피드 조회
-* 토픽 구독 관리
-* 이벤트 좋아요 기능
-* 토픽 타임라인 조회
+* 토픽 관리 및 구독 기능
+* 이벤트 상호작용 (좋아요, 기록)
+* 사용자 프로필 관리
+* 푸시 알림 서비스
 
 == Authentication
 
@@ -39,7 +40,7 @@ Authorization: Bearer <JWT_TOKEN>
 [source,json]
 ----
 {
-  "status": "SUCCESS",
+  "code": 200,
   "message": "요청이 성공적으로 처리되었습니다.",
   "data": { /* 실제 데이터 */ }
 }
@@ -48,12 +49,12 @@ Authorization: Bearer <JWT_TOKEN>
 [[resources]]
 = Resources
 
+[[resources-event]]
+== Event
+
+이벤트 관련 API입니다.
+
 [[resources-event-feed]]
-== Event Feed
-
-이벤트 피드 관련 API입니다.
-
-[[resources-event-feed-query]]
 === Get Event Feed
 
 사용자별 개인화된 이벤트 피드를 조회합니다.
@@ -69,31 +70,86 @@ include::{snippets}/event-feed-query/http-response.adoc[]
 include::{snippets}/event-feed-query/response-fields.adoc[]
 
 [[resources-event-like]]
-== Event Like
-
-이벤트 좋아요 관련 API입니다.
-
-[[resources-event-like-toggle]]
 === Toggle Event Like
 
 특정 이벤트에 대한 좋아요를 토글합니다.
 
-include::{snippets}/event-like-toggle/curl-request.adoc[]
+include::{snippets}/event-like/curl-request.adoc[]
 
-include::{snippets}/event-like-toggle/http-request.adoc[]
+include::{snippets}/event-like/http-request.adoc[]
 
-include::{snippets}/event-like-toggle/path-parameters.adoc[]
+include::{snippets}/event-like/path-parameters.adoc[]
 
-include::{snippets}/event-like-toggle/http-response.adoc[]
+include::{snippets}/event-like/http-response.adoc[]
 
-include::{snippets}/event-like-toggle/response-fields.adoc[]
+include::{snippets}/event-like/response-fields.adoc[]
+
+[[resources-topic]]
+== Topic
+
+토픽 관련 API입니다.
+
+[[resources-topic-list]]
+=== Get All Topics
+
+모든 토픽 목록을 조회합니다.
+
+include::{snippets}/topic-list-query/curl-request.adoc[]
+
+include::{snippets}/topic-list-query/http-request.adoc[]
+
+include::{snippets}/topic-list-query/query-parameters.adoc[]
+
+include::{snippets}/topic-list-query/http-response.adoc[]
+
+include::{snippets}/topic-list-query/response-fields.adoc[]
+
+[[resources-topic-topk]]
+=== Get Top K Topics
+
+상위 K개 토픽을 조회합니다.
+
+include::{snippets}/topic-topk-query/curl-request.adoc[]
+
+include::{snippets}/topic-topk-query/http-request.adoc[]
+
+include::{snippets}/topic-topk-query/query-parameters.adoc[]
+
+include::{snippets}/topic-topk-query/http-response.adoc[]
+
+include::{snippets}/topic-topk-query/response-fields.adoc[]
+
+[[resources-topic-search]]
+=== Search Topics
+
+키워드로 토픽을 검색합니다.
+
+include::{snippets}/topic-search-query/curl-request.adoc[]
+
+include::{snippets}/topic-search-query/http-request.adoc[]
+
+include::{snippets}/topic-search-query/query-parameters.adoc[]
+
+include::{snippets}/topic-search-query/http-response.adoc[]
+
+include::{snippets}/topic-search-query/response-fields.adoc[]
+
+[[resources-topic-timeline]]
+=== Get Topic Timeline
+
+특정 토픽의 타임라인을 조회합니다.
+
+include::{snippets}/topic-timeline-query/curl-request.adoc[]
+
+include::{snippets}/topic-timeline-query/http-request.adoc[]
+
+include::{snippets}/topic-timeline-query/path-parameters.adoc[]
+
+include::{snippets}/topic-timeline-query/http-response.adoc[]
+
+include::{snippets}/topic-timeline-query/response-fields.adoc[]
 
 [[resources-topic-subscription]]
-== Topic Subscription
-
-토픽 구독 관련 API입니다.
-
-[[resources-topic-subscription-toggle]]
 === Toggle Topic Subscription
 
 특정 토픽에 대한 구독을 토글합니다.
@@ -108,25 +164,95 @@ include::{snippets}/topic-subscription-toggle/http-response.adoc[]
 
 include::{snippets}/topic-subscription-toggle/response-fields.adoc[]
 
-[[resources-topic-timeline]]
-== Topic Timeline
+[[resources-interaction]]
+== Interaction
 
-토픽 타임라인 관련 API입니다.
+사용자 상호작용 관련 API입니다.
 
-[[resources-topic-timeline-query]]
-=== Get Topic Timeline
+[[resources-interaction-record]]
+=== Record Interaction
 
-특정 토픽의 타임라인을 조회합니다.
+사용자의 이벤트 상호작용을 기록합니다.
 
-include::{snippets}/topic-timeline-query/curl-request.adoc[]
+include::{snippets}/interaction-record/curl-request.adoc[]
 
-include::{snippets}/topic-timeline-query/http-request.adoc[]
+include::{snippets}/interaction-record/http-request.adoc[]
 
-include::{snippets}/topic-timeline-query/path-parameters.adoc[]
+include::{snippets}/interaction-record/request-fields.adoc[]
 
-include::{snippets}/topic-timeline-query/http-response.adoc[]
+include::{snippets}/interaction-record/http-response.adoc[]
 
-include::{snippets}/topic-timeline-query/response-fields.adoc[]
+include::{snippets}/interaction-record/response-fields.adoc[]
+
+[[resources-user]]
+== User
+
+사용자 관련 API입니다.
+
+[[resources-user-current]]
+=== Get Current User
+
+현재 사용자 정보를 조회합니다.
+
+include::{snippets}/user-current-query/curl-request.adoc[]
+
+include::{snippets}/user-current-query/http-request.adoc[]
+
+include::{snippets}/user-current-query/http-response.adoc[]
+
+include::{snippets}/user-current-query/response-fields.adoc[]
+
+[[resources-user-device-token]]
+=== Update Device Token
+
+사용자의 디바이스 토큰을 업데이트합니다.
+
+include::{snippets}/user-device-token-update/curl-request.adoc[]
+
+include::{snippets}/user-device-token-update/http-request.adoc[]
+
+include::{snippets}/user-device-token-update/request-fields.adoc[]
+
+include::{snippets}/user-device-token-update/http-response.adoc[]
+
+include::{snippets}/user-device-token-update/response-fields.adoc[]
+
+[[resources-user-withdrawal]]
+=== Withdraw User
+
+사용자 탈퇴를 처리합니다.
+
+include::{snippets}/user-withdrawal/curl-request.adoc[]
+
+include::{snippets}/user-withdrawal/http-request.adoc[]
+
+include::{snippets}/user-withdrawal/request-fields.adoc[]
+
+include::{snippets}/user-withdrawal/http-response.adoc[]
+
+include::{snippets}/user-withdrawal/response-fields.adoc[]
+
+[[resources-push]]
+== Push Notification
+
+푸시 알림 관련 API입니다.
+
+[[resources-push-send-by-topic]]
+=== Send Push Message by Topic
+
+토픽 기반으로 푸시 메시지를 전송합니다.
+
+include::{snippets}/push-message-send-by-topic/curl-request.adoc[]
+
+include::{snippets}/push-message-send-by-topic/http-request.adoc[]
+
+include::{snippets}/push-message-send-by-topic/query-parameters.adoc[]
+
+include::{snippets}/push-message-send-by-topic/request-fields.adoc[]
+
+include::{snippets}/push-message-send-by-topic/http-response.adoc[]
+
+include::{snippets}/push-message-send-by-topic/response-fields.adoc[]
 
 [[openapi-spec]]
 == OpenAPI 3.0 Specification

--- a/src/main/kotlin/com/flownews/api/interaction/api/InteractionRecordApi.kt
+++ b/src/main/kotlin/com/flownews/api/interaction/api/InteractionRecordApi.kt
@@ -18,8 +18,7 @@ class InteractionRecordApi(
         @RequestBody request: InteractionRecordRequest,
         @CurrentUser user: User,
     ): ApiResponse<Void?> {
-        val withUserId = request.with(user.requireId())
-        interactionRecordService.recordInteraction(withUserId)
+        interactionRecordService.recordInteraction(request, user)
 
         return ApiResponse.ok()
     }

--- a/src/main/kotlin/com/flownews/api/interaction/app/InteractionRecordRequest.kt
+++ b/src/main/kotlin/com/flownews/api/interaction/app/InteractionRecordRequest.kt
@@ -5,7 +5,4 @@ import com.flownews.api.interaction.domain.InteractionType
 data class InteractionRecordRequest(
     val eventId: Long,
     val interactionType: InteractionType,
-    val userId: Long,
-) {
-    fun with(userId: Long) = copy(userId = userId)
-}
+)

--- a/src/main/kotlin/com/flownews/api/interaction/app/InteractionRecordService.kt
+++ b/src/main/kotlin/com/flownews/api/interaction/app/InteractionRecordService.kt
@@ -19,8 +19,12 @@ class InteractionRecordService(
     private val eventQueryService: EventQueryService,
     private val userProfileApiClient: UserProfileApiClient,
 ) {
-    fun recordInteraction(request: InteractionRecordRequest): Interaction {
-        val (eventId, interactionType, userId) = request
+    fun recordInteraction(
+        request: InteractionRecordRequest,
+        user: User,
+    ): Interaction {
+        val (eventId, interactionType) = request
+        val userId = user.requireId()
 
         val user = findUserById(userId)
         val event = eventQueryService.findEventById(eventId)

--- a/src/main/kotlin/com/flownews/api/user/api/UserProfileUpdateApi.kt
+++ b/src/main/kotlin/com/flownews/api/user/api/UserProfileUpdateApi.kt
@@ -3,7 +3,6 @@ package com.flownews.api.user.api
 import com.flownews.api.common.api.ApiResponse
 import com.flownews.api.common.api.CurrentUser
 import com.flownews.api.user.app.UserDeviceTokenUpdateRequest
-import com.flownews.api.user.app.UserProfileUpdateRequest
 import com.flownews.api.user.app.UserUpdateService
 import com.flownews.api.user.app.UserWithdrawRequest
 import com.flownews.api.user.domain.User
@@ -15,16 +14,6 @@ import org.springframework.web.bind.annotation.RestController
 class UserProfileUpdateApi(
     private val userUpdateService: UserUpdateService,
 ) {
-    @PostMapping("/api/users/profile")
-    fun updateProfile(
-        @CurrentUser user: User,
-        @RequestBody request: UserProfileUpdateRequest?,
-    ): ApiResponse<Void?> {
-        userUpdateService.updateProfile(request, user.requireId())
-
-        return ApiResponse.ok()
-    }
-
     @PostMapping("/api/users/device-token")
     fun updateDeviceToken(
         @CurrentUser user: User,

--- a/src/main/kotlin/com/flownews/api/user/api/UserProfileUpdateApi.kt
+++ b/src/main/kotlin/com/flownews/api/user/api/UserProfileUpdateApi.kt
@@ -1,5 +1,6 @@
 package com.flownews.api.user.api
 
+import com.flownews.api.common.api.ApiResponse
 import com.flownews.api.common.api.CurrentUser
 import com.flownews.api.user.app.UserDeviceTokenUpdateRequest
 import com.flownews.api.user.app.UserProfileUpdateRequest
@@ -18,24 +19,30 @@ class UserProfileUpdateApi(
     fun updateProfile(
         @CurrentUser user: User,
         @RequestBody request: UserProfileUpdateRequest?,
-    ) {
+    ): ApiResponse<Void?> {
         userUpdateService.updateProfile(request, user.requireId())
+
+        return ApiResponse.ok()
     }
 
     @PostMapping("/api/users/device-token")
     fun updateDeviceToken(
         @CurrentUser user: User,
         @RequestBody request: UserDeviceTokenUpdateRequest,
-    ) {
+    ): ApiResponse<Void?> {
         val withUserId = request.withUserId(user.requireId())
         userUpdateService.updateDeviceToken(withUserId)
+
+        return ApiResponse.ok()
     }
 
     @PostMapping("/api/users/withdraw")
     fun withdraw(
         @CurrentUser user: User,
         @RequestBody request: UserWithdrawRequest,
-    ) {
+    ): ApiResponse<Void?> {
         userUpdateService.withdraw(user.requireId(), request)
+
+        return ApiResponse.ok()
     }
 }

--- a/src/main/kotlin/com/flownews/api/user/app/UserQueryResponse.kt
+++ b/src/main/kotlin/com/flownews/api/user/app/UserQueryResponse.kt
@@ -8,7 +8,6 @@ data class UserQueryResponse(
     val email: String,
     val profileUrl: String?,
     val role: String,
-    val isProfileComplete: Boolean,
 ) {
     companion object {
         fun from(user: User): UserQueryResponse =
@@ -18,7 +17,6 @@ data class UserQueryResponse(
                 email = user.email,
                 profileUrl = user.profileUrl,
                 role = user.role.name,
-                isProfileComplete = user.isProfileComplete,
             )
     }
 }

--- a/src/main/kotlin/com/flownews/api/user/app/UserUpdateService.kt
+++ b/src/main/kotlin/com/flownews/api/user/app/UserUpdateService.kt
@@ -20,20 +20,6 @@ class UserUpdateService(
     }
 
     @Transactional
-    fun updateProfile(
-        request: UserProfileUpdateRequest?,
-        userId: Long,
-    ): User {
-        val birthDate = request?.birthDate
-        val gender = request?.gender
-        val user = getUser(userId)
-
-        user.updateProfile(birthDate, gender)
-
-        return userRepository.save(user)
-    }
-
-    @Transactional
     fun withdraw(
         userId: Long,
         request: UserWithdrawRequest,

--- a/src/main/kotlin/com/flownews/api/user/domain/User.kt
+++ b/src/main/kotlin/com/flownews/api/user/domain/User.kt
@@ -1,7 +1,6 @@
 package com.flownews.api.user.domain
 
 import BaseEntity
-import com.flownews.api.user.domain.enums.Gender
 import com.flownews.api.user.domain.enums.Role
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -11,7 +10,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity
@@ -35,17 +33,10 @@ class User(
     val role: Role,
     @Column(name = "device_token")
     var deviceToken: String? = null,
-    @Column(name = "birth_date")
-    var birthDate: LocalDate? = null,
-    @Column(name = "gender")
-    @Enumerated(EnumType.STRING)
-    var gender: Gender? = null,
     @Column(name = "deleted_at")
     var deletedAt: LocalDateTime? = null,
     @Column(name = "delete_reason")
     var deleteReason: String? = null,
-    @Column(name = "is_profile_complete")
-    var isProfileComplete: Boolean = false,
 ) : BaseEntity() {
     fun requireId(): Long = id ?: throw IllegalStateException("User ID cannot be null")
 
@@ -53,15 +44,6 @@ class User(
         if (newDeviceToken == null) return
 
         this.deviceToken = newDeviceToken
-    }
-
-    fun updateProfile(
-        birthDate: LocalDate?,
-        gender: Gender?,
-    ) {
-        this.birthDate = birthDate
-        this.gender = gender
-        this.isProfileComplete = true
     }
 
     fun withdraw(reason: String?) {

--- a/src/test/kotlin/com/flownews/api/event/api/EventFeedQueryApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/event/api/EventFeedQueryApiTest.kt
@@ -5,17 +5,15 @@ import com.flownews.api.event.app.EventFeedQueryResponse
 import com.flownews.api.event.app.EventFeedQueryService
 import com.flownews.api.event.app.TopicSimpleInfo
 import com.flownews.testutils.ApiResponseFieldSpecs
-import com.flownews.testutils.MockCurrentUserArgumentResolver
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.Mockito.`when`
-import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
+import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -27,31 +25,18 @@ import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 import java.time.LocalDateTime
 
-@ExtendWith(RestDocumentationExtension::class, MockitoExtension::class)
+@ExtendWith(RestDocumentationExtension::class)
 class EventFeedQueryApiTest {
     private lateinit var mockMvc: MockMvc
 
-    @Mock
-    private lateinit var eventFeedQueryService: EventFeedQueryService
+    private val eventFeedQueryService = mockk<EventFeedQueryService>()
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
         val controller = EventFeedQueryApi(eventFeedQueryService)
-
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(controller)
-                .setCustomArgumentResolvers(MockCurrentUserArgumentResolver())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        this.mockMvc = MockMvcTestUtils.createMockMvc(controller, restDocumentation)
     }
 
     @Test
@@ -64,19 +49,19 @@ class EventFeedQueryApiTest {
                     title = "AI 기술의 새로운 혁신",
                     description = "최신 AI 기술 동향과 발전 방향",
                     imageUrl = "https://example.com/image1.jpg",
-                    eventTime = LocalDateTime.of(2024, 12, 4, 10, 30, 0),
+                    eventTime = LocalDateTime.now(),
                     likeCount = 15L,
                 ),
             )
 
-        `when`(eventFeedQueryService.getEventFeeds(any(), any())).thenReturn(mockResponse)
+        every { eventFeedQueryService.getEventFeeds(any(), any()) } returns mockResponse
 
         mockMvc.perform(
             get("/api/events/feed")
-                .param("category", "technology"),
+                .param("category", "기술"),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "event-feed-query",
@@ -84,20 +69,19 @@ class EventFeedQueryApiTest {
                     preprocessResponse(prettyPrint()),
                     queryParameters(
                         parameterWithName("category")
-                            .description("이벤트 카테고리 필터 (선택사항)")
-                            .optional(),
+                            .description("피드 카테고리 필터").optional(),
                     ),
                     responseFields(
-                        *ApiResponseFieldSpecs.responseWithData("이벤트 피드 데이터 배열"),
-                        fieldWithPath("data[].id").description("이벤트 ID"),
+                        *ApiResponseFieldSpecs.responseWithData("피드 리스트"),
+                        fieldWithPath("data[].id").description("피드 ID"),
                         fieldWithPath("data[].topic").description("토픽 정보"),
                         fieldWithPath("data[].topic.id").description("토픽 ID"),
                         fieldWithPath("data[].topic.title").description("토픽 제목"),
-                        fieldWithPath("data[].title").description("이벤트 제목"),
-                        fieldWithPath("data[].description").description("이벤트 설명"),
-                        fieldWithPath("data[].imageUrl").description("이벤트 이미지 URL"),
-                        fieldWithPath("data[].eventTime").description("이벤트 발생 시간 (ISO 8601 형식)"),
-                        fieldWithPath("data[].likeCount").description("이벤트 좋아요 수"),
+                        fieldWithPath("data[].title").description("피드 제목"),
+                        fieldWithPath("data[].description").description("피드 설명"),
+                        fieldWithPath("data[].imageUrl").description("피드 이미지 URL"),
+                        fieldWithPath("data[].eventTime").description("피드 발생 시간(YYYY-MM-DDTHH:mm:ss)"),
+                        fieldWithPath("data[].likeCount").description("피드 좋아요 수"),
                     ),
                 ),
             )

--- a/src/test/kotlin/com/flownews/api/event/api/EventLikeApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/event/api/EventLikeApiTest.kt
@@ -3,16 +3,14 @@ package com.flownews.api.event.api
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
 import com.flownews.api.event.app.EventLikeService
 import com.flownews.testutils.ApiResponseFieldSpecs
-import com.flownews.testutils.MockCurrentUserArgumentResolver
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -23,30 +21,17 @@ import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 
-@ExtendWith(RestDocumentationExtension::class, MockitoExtension::class)
+@ExtendWith(RestDocumentationExtension::class)
 class EventLikeApiTest {
     private lateinit var mockMvc: MockMvc
 
-    @Mock
-    private lateinit var eventLikeService: EventLikeService
+    private val eventLikeService = mockk<EventLikeService>(relaxed = true)
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
         val controller = EventLikeApi(eventLikeService)
-
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(controller)
-                .setCustomArgumentResolvers(MockCurrentUserArgumentResolver())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        this.mockMvc = MockMvcTestUtils.createMockMvc(controller, restDocumentation)
     }
 
     @Test
@@ -56,17 +41,17 @@ class EventLikeApiTest {
                 .contentType(MediaType.APPLICATION_JSON),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
-                    "event-like-toggle",
+                    "event-like",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     pathParameters(
                         parameterWithName("eventId").description("이벤트 ID"),
                     ),
                     responseFields(
-                        *ApiResponseFieldSpecs.responseWithOptionalData("응답 데이터 (이 엔드포인트에서는 null)"),
+                        *ApiResponseFieldSpecs.responseWithOptionalData(),
                     ),
                 ),
             )

--- a/src/test/kotlin/com/flownews/api/interaction/api/InteractionRecordApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/interaction/api/InteractionRecordApiTest.kt
@@ -1,13 +1,16 @@
 package com.flownews.api.interaction.api
 
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.flownews.api.interaction.app.InteractionRecordService
+import com.flownews.testutils.ApiResponseFieldSpecs
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -18,27 +21,16 @@ import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
 
 @ExtendWith(RestDocumentationExtension::class)
 class InteractionRecordApiTest {
     private lateinit var mockMvc: MockMvc
+    private val interactionRecordService = mockk<InteractionRecordService>(relaxed = true)
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(MockInteractionRecordController())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        var controller = InteractionRecordApi(interactionRecordService)
+        this.mockMvc = MockMvcTestUtils.createMockMvc(controller, restDocumentation)
     }
 
     @Test
@@ -50,52 +42,31 @@ class InteractionRecordApiTest {
                 .content(
                     """
                     {
-                        "eventId": 1, 
-                        "interactionType": "VIEW", 
-                        "metadata": {
-                            "source": "mobile_app", 
-                            "duration": 30
-                        }
+                        "eventId": 1,
+                        "interactionType": "VIEWED"
                     }
                     """.trimIndent(),
                 ),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "interaction-record",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestFields(
-                        fieldWithPath("eventId").description("Event ID that user interacted with"),
-                        fieldWithPath("interactionType").description("Type of interaction (VIEW, CLICK, SHARE, etc.)"),
-                        fieldWithPath("metadata").description("Additional interaction metadata").optional(),
+                        fieldWithPath("eventId").description("사용자가 상호작용한 이벤트 ID"),
                         fieldWithPath(
-                            "metadata.source",
-                        ).description("Source of interaction (mobile_app, web, etc.)").optional(),
-                        fieldWithPath("metadata.duration").description("Duration of interaction in seconds").optional(),
+                            "interactionType",
+                        ).description(
+                            "상호작용 유형 (VIEWED, ARTICLE_CLICKED, TOPIC_VIEWED, TOPIC_FOLLOWED, TOPIC_UNFOLLOWED)",
+                        ),
                     ),
                     responseFields(
-                        fieldWithPath("status").description("Response status (SUCCESS, ERROR)"),
-                        fieldWithPath("message").description("Response message"),
-                        fieldWithPath("data").description("Response data (null for this endpoint)").optional(),
+                        *ApiResponseFieldSpecs.responseWithOptionalData(),
                     ),
                 ),
             )
-    }
-
-    @RestController
-    class MockInteractionRecordController {
-        @PostMapping("/api/interactions")
-        fun recordInteraction(
-            @RequestBody request: Map<String, Any>,
-        ): Map<String, Any?> {
-            return mapOf(
-                "status" to "SUCCESS",
-                "message" to "사용자 상호작용이 성공적으로 기록되었습니다.",
-                "data" to null,
-            )
-        }
     }
 }

--- a/src/test/kotlin/com/flownews/api/push/api/PushMessageSendApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/push/api/PushMessageSendApiTest.kt
@@ -1,13 +1,16 @@
 package com.flownews.api.push.api
 
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.flownews.api.push.app.PushMessageSender
+import com.flownews.testutils.ApiResponseFieldSpecs
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -20,28 +23,17 @@ import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.controller
 
 @ExtendWith(RestDocumentationExtension::class)
 class PushMessageSendApiTest {
     private lateinit var mockMvc: MockMvc
+    private val pushSender = mockk<PushMessageSender>(relaxed = true)
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(MockPushMessageSendController())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        val controller = PushMessageSendApi(pushSender)
+        this.mockMvc = MockMvcTestUtils.createMockMvcWithoutAuth(controller, restDocumentation)
     }
 
     @Test
@@ -52,47 +44,24 @@ class PushMessageSendApiTest {
                 .content("""{"topicId": 1, "title": "새로운 이벤트", "body": "AI 기술 관련 새로운 이벤트가 등록되었습니다."}"""),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "push-message-send-by-topic",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     queryParameters(
-                        parameterWithName("by").description("Push message target type (topic)"),
+                        parameterWithName("by").description("Push 종류"),
                     ),
                     requestFields(
-                        fieldWithPath("topicId").description("Topic ID to send push message to"),
-                        fieldWithPath("title").description("Push notification title"),
-                        fieldWithPath("body").description("Push notification body content"),
+                        fieldWithPath("topicId").description("토픽 ID"),
+                        fieldWithPath("title").description("푸시 알림 제목"),
+                        fieldWithPath("body").description("푸시 알림 본문 내용"),
                     ),
                     responseFields(
-                        fieldWithPath("status").description("Response status (SUCCESS, ERROR)"),
-                        fieldWithPath("message").description("Response message"),
-                        fieldWithPath("data").description("Push message send result data"),
-                        fieldWithPath("data.sentCount").description("Number of push messages sent"),
-                        fieldWithPath("data.targetUsers").description("Number of target users"),
+                        *ApiResponseFieldSpecs.responseWithOptionalData(),
                     ),
                 ),
             )
-    }
-
-    @RestController
-    class MockPushMessageSendController {
-        @PostMapping("/api/notifications/push", params = ["by=topic"])
-        fun sendPushMessageByTopic(
-            @RequestBody request: Map<String, Any>,
-            @RequestParam by: String,
-        ): Map<String, Any> {
-            return mapOf(
-                "status" to "SUCCESS",
-                "message" to "푸시 메시지가 성공적으로 전송되었습니다.",
-                "data" to
-                    mapOf(
-                        "sentCount" to 15,
-                        "targetUsers" to 15,
-                    ),
-            )
-        }
     }
 }

--- a/src/test/kotlin/com/flownews/api/push/api/PushMessageSendApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/push/api/PushMessageSendApiTest.kt
@@ -41,7 +41,7 @@ class PushMessageSendApiTest {
         mockMvc.perform(
             post("/api/notifications/push?by=topic")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"topicId": 1, "title": "새로운 이벤트", "body": "AI 기술 관련 새로운 이벤트가 등록되었습니다."}"""),
+                .content("""{"topicId": 1}"""),
         )
             .andExpect(status().isOk)
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -55,8 +55,6 @@ class PushMessageSendApiTest {
                     ),
                     requestFields(
                         fieldWithPath("topicId").description("토픽 ID"),
-                        fieldWithPath("title").description("푸시 알림 제목"),
-                        fieldWithPath("body").description("푸시 알림 본문 내용"),
                     ),
                     responseFields(
                         *ApiResponseFieldSpecs.responseWithOptionalData(),

--- a/src/test/kotlin/com/flownews/api/topic/api/TopicListQueryApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/topic/api/TopicListQueryApiTest.kt
@@ -5,16 +5,15 @@ import com.flownews.api.topic.app.TopicListQueryResponse
 import com.flownews.api.topic.app.TopicListQueryService
 import com.flownews.api.topic.app.TopicTopKQueryResponse
 import com.flownews.testutils.ApiResponseFieldSpecs
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.Mockito.`when`
-import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
+import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -26,29 +25,18 @@ import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 
-@ExtendWith(RestDocumentationExtension::class, MockitoExtension::class)
+@ExtendWith(RestDocumentationExtension::class)
 class TopicListQueryApiTest {
     private lateinit var mockMvc: MockMvc
 
-    @Mock
-    private lateinit var topicListQueryService: TopicListQueryService
+    private val topicListQueryService = mockk<TopicListQueryService>()
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
         val controller = TopicListQueryApi(topicListQueryService)
 
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(controller)
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        this.mockMvc = MockMvcTestUtils.createMockMvcWithoutAuth(controller, restDocumentation)
     }
 
     @Test
@@ -67,7 +55,7 @@ class TopicListQueryApiTest {
                 ),
             )
 
-        `when`(topicListQueryService.getTopics(any())).thenReturn(mockTopics)
+        every { topicListQueryService.getTopics(any()) } returns mockTopics
 
         mockMvc.perform(
             get("/api/topics")
@@ -75,21 +63,21 @@ class TopicListQueryApiTest {
                 .param("size", "10"),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "topic-list-query",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     queryParameters(
-                        parameterWithName("page").description("Page number (0-based, optional)").optional(),
-                        parameterWithName("size").description("Page size (optional)").optional(),
+                        parameterWithName("page").description("페이지 번호 (0부터 시작, 선택사항)").optional(),
+                        parameterWithName("size").description("페이지 크기 (선택사항)").optional(),
                     ),
                     responseFields(
-                        *ApiResponseFieldSpecs.responseWithData("Topic list data as array"),
-                        fieldWithPath("data[].id").description("Topic ID"),
-                        fieldWithPath("data[].title").description("Topic title"),
-                        fieldWithPath("data[].description").description("Topic description"),
+                        *ApiResponseFieldSpecs.responseWithData("토픽 목록 배열 데이터"),
+                        fieldWithPath("data[].id").description("토픽 ID"),
+                        fieldWithPath("data[].title").description("토픽 제목"),
+                        fieldWithPath("data[].description").description("토픽 설명"),
                     ),
                 ),
             )
@@ -105,28 +93,26 @@ class TopicListQueryApiTest {
                 ),
             )
 
-        `when`(topicListQueryService.getTopKTopics(any())).thenReturn(mockTopKTopics)
+        every { topicListQueryService.getTopKTopics(any()) } returns mockTopKTopics
 
         mockMvc.perform(
             get("/api/topics/topk")
                 .param("limit", "5"),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "topic-topk-query",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     queryParameters(
-                        parameterWithName(
-                            "limit",
-                        ).description("Number of top topics to retrieve (default: 5)").optional(),
+                        parameterWithName("limit").description("조회할 상위 토픽 수 (기본값: 5)").optional(),
                     ),
                     responseFields(
-                        *ApiResponseFieldSpecs.responseWithData("Top K topics data as array"),
-                        fieldWithPath("data[].id").description("Topic ID"),
-                        fieldWithPath("data[].title").description("Topic title"),
+                        *ApiResponseFieldSpecs.responseWithData("상위 K개 토픽 배열 데이터"),
+                        fieldWithPath("data[].id").description("토픽 ID"),
+                        fieldWithPath("data[].title").description("토픽 제목"),
                     ),
                 ),
             )
@@ -143,27 +129,27 @@ class TopicListQueryApiTest {
                 ),
             )
 
-        `when`(topicListQueryService.getTopicsByKeyword(any())).thenReturn(mockSearchResults)
+        every { topicListQueryService.getTopicsByKeyword(any()) } returns mockSearchResults
 
         mockMvc.perform(
             get("/api/topics/search")
                 .param("keyword", "AI"),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "topic-search-query",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     queryParameters(
-                        parameterWithName("keyword").description("Search keyword for topic title or description"),
+                        parameterWithName("keyword").description("토픽 제목 또는 설명 검색 키워드"),
                     ),
                     responseFields(
-                        *ApiResponseFieldSpecs.responseWithData("Search results data as array"),
-                        fieldWithPath("data[].id").description("Topic ID"),
-                        fieldWithPath("data[].title").description("Topic title"),
-                        fieldWithPath("data[].description").description("Topic description"),
+                        *ApiResponseFieldSpecs.responseWithData("검색 결과 배열 데이터"),
+                        fieldWithPath("data[].id").description("토픽 ID"),
+                        fieldWithPath("data[].title").description("토픽 제목"),
+                        fieldWithPath("data[].description").description("토픽 설명"),
                     ),
                 ),
             )

--- a/src/test/kotlin/com/flownews/api/topic/api/TopicSubscribeApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/topic/api/TopicSubscribeApiTest.kt
@@ -3,16 +3,14 @@ package com.flownews.api.topic.api
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
 import com.flownews.api.topic.app.TopicSubscribeService
 import com.flownews.testutils.ApiResponseFieldSpecs
-import com.flownews.testutils.MockCurrentUserArgumentResolver
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -23,30 +21,18 @@ import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 
-@ExtendWith(RestDocumentationExtension::class, MockitoExtension::class)
+@ExtendWith(RestDocumentationExtension::class)
 class TopicSubscribeApiTest {
     private lateinit var mockMvc: MockMvc
 
-    @Mock
-    private lateinit var topicSubscribeService: TopicSubscribeService
+    private val topicSubscribeService = mockk<TopicSubscribeService>(relaxed = true)
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
         val controller = TopicSubscribeApi(topicSubscribeService)
 
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(controller)
-                .setCustomArgumentResolvers(MockCurrentUserArgumentResolver())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        this.mockMvc = MockMvcTestUtils.createMockMvc(controller, restDocumentation)
     }
 
     @Test
@@ -56,7 +42,7 @@ class TopicSubscribeApiTest {
                 .contentType(MediaType.APPLICATION_JSON),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "topic-subscription-toggle",
@@ -66,7 +52,7 @@ class TopicSubscribeApiTest {
                         parameterWithName("topicId").description("토픽 ID"),
                     ),
                     responseFields(
-                        *ApiResponseFieldSpecs.responseWithOptionalData("응답 데이터 (이 엔드포인트에서는 null)"),
+                        *ApiResponseFieldSpecs.responseWithOptionalData(),
                     ),
                 ),
             )

--- a/src/test/kotlin/com/flownews/api/topic/api/TopicTimelineQueryApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/topic/api/TopicTimelineQueryApiTest.kt
@@ -6,17 +6,15 @@ import com.flownews.api.topic.app.EventItemQueryResponse
 import com.flownews.api.topic.app.TopicTimelineQueryResponse
 import com.flownews.api.topic.app.TopicTimelineQueryService
 import com.flownews.testutils.ApiResponseFieldSpecs
-import com.flownews.testutils.MockCurrentUserArgumentResolver
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.Mockito.`when`
-import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
+import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -28,31 +26,19 @@ import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 import java.time.LocalDateTime
 
-@ExtendWith(RestDocumentationExtension::class, MockitoExtension::class)
+@ExtendWith(RestDocumentationExtension::class)
 class TopicTimelineQueryApiTest {
     private lateinit var mockMvc: MockMvc
 
-    @Mock
-    private lateinit var topicTimelineQueryService: TopicTimelineQueryService
+    private val topicTimelineQueryService = mockk<TopicTimelineQueryService>()
 
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
         val controller = TopicTimelineQueryApi(topicTimelineQueryService)
 
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(controller)
-                .setCustomArgumentResolvers(MockCurrentUserArgumentResolver())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        this.mockMvc = MockMvcTestUtils.createMockMvc(controller, restDocumentation)
     }
 
     @Test
@@ -86,13 +72,13 @@ class TopicTimelineQueryApiTest {
                 isFollowing = true,
             )
 
-        `when`(topicTimelineQueryService.getTopic(any(), any())).thenReturn(mockResponse)
+        every { topicTimelineQueryService.getTopic(any(), any()) } returns mockResponse
 
         mockMvc.perform(
             get("/api/topics/{topicId}", 1L),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "topic-timeline-query",

--- a/src/test/kotlin/com/flownews/api/user/api/UserProfileUpdateApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/user/api/UserProfileUpdateApiTest.kt
@@ -35,39 +35,12 @@ class UserProfileUpdateApiTest {
     }
 
     @Test
-    fun `should document user profile update`() {
-        mockMvc.perform(
-            post("/api/users/profile")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-                .content("""{"nickname": "새로운닉네임", "birthDate": "1990-05-15", "gender": "MALE"}"""),
-        )
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andDo(
-                document(
-                    "user-profile-update",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    requestFields(
-                        fieldWithPath("nickname").description("사용자 닉네임").optional(),
-                        fieldWithPath("birthDate").description("사용자 생년월일 (YYYY-MM-DD 형식)").optional(),
-                        fieldWithPath("gender").description("사용자 성별 (MALE, FEMALE, OTHER)").optional(),
-                    ),
-                    responseFields(
-                        *ApiResponseFieldSpecs.responseWithOptionalData(),
-                    ),
-                ),
-            )
-    }
-
-    @Test
     fun `should document device token update`() {
         mockMvc.perform(
             post("/api/users/device-token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-                .content("""{"deviceToken": "fcm_device_token_12345", "deviceType": "ANDROID"}"""),
+                .content("""{"deviceToken": "fcm_device_token_12345"}"""),
         )
             .andExpect(status().isOk)
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -78,7 +51,6 @@ class UserProfileUpdateApiTest {
                     preprocessResponse(prettyPrint()),
                     requestFields(
                         fieldWithPath("deviceToken").description("푸시 알림용 FCM 디바이스 토큰"),
-                        fieldWithPath("deviceType").description("디바이스 유형 (ANDROID, IOS)"),
                     ),
                     responseFields(
                         *ApiResponseFieldSpecs.responseWithOptionalData(),

--- a/src/test/kotlin/com/flownews/api/user/api/UserProfileUpdateApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/user/api/UserProfileUpdateApiTest.kt
@@ -1,13 +1,16 @@
 package com.flownews.api.user.api
 
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.flownews.api.user.app.UserUpdateService
+import com.flownews.testutils.ApiResponseFieldSpecs
+import com.flownews.testutils.MockMvcTestUtils
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -18,27 +21,17 @@ import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
 
 @ExtendWith(RestDocumentationExtension::class)
 class UserProfileUpdateApiTest {
     private lateinit var mockMvc: MockMvc
 
+    private val userUpdateService = mockk<UserUpdateService>(relaxed = true)
+
     @BeforeEach
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(MockUserProfileUpdateController())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        val controller = UserProfileUpdateApi(userUpdateService)
+        this.mockMvc = MockMvcTestUtils.createMockMvc(controller, restDocumentation)
     }
 
     @Test
@@ -50,21 +43,19 @@ class UserProfileUpdateApiTest {
                 .content("""{"nickname": "새로운닉네임", "birthDate": "1990-05-15", "gender": "MALE"}"""),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "user-profile-update",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestFields(
-                        fieldWithPath("nickname").description("User nickname").optional(),
-                        fieldWithPath("birthDate").description("User birth date in YYYY-MM-DD format").optional(),
-                        fieldWithPath("gender").description("User gender (MALE, FEMALE, OTHER)").optional(),
+                        fieldWithPath("nickname").description("사용자 닉네임").optional(),
+                        fieldWithPath("birthDate").description("사용자 생년월일 (YYYY-MM-DD 형식)").optional(),
+                        fieldWithPath("gender").description("사용자 성별 (MALE, FEMALE, OTHER)").optional(),
                     ),
                     responseFields(
-                        fieldWithPath("status").description("Response status (SUCCESS, ERROR)"),
-                        fieldWithPath("message").description("Response message"),
-                        fieldWithPath("data").description("Response data (null for this endpoint)").optional(),
+                        *ApiResponseFieldSpecs.responseWithOptionalData(),
                     ),
                 ),
             )
@@ -79,20 +70,18 @@ class UserProfileUpdateApiTest {
                 .content("""{"deviceToken": "fcm_device_token_12345", "deviceType": "ANDROID"}"""),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "user-device-token-update",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestFields(
-                        fieldWithPath("deviceToken").description("FCM device token for push notifications"),
-                        fieldWithPath("deviceType").description("Device type (ANDROID, IOS)"),
+                        fieldWithPath("deviceToken").description("푸시 알림용 FCM 디바이스 토큰"),
+                        fieldWithPath("deviceType").description("디바이스 유형 (ANDROID, IOS)"),
                     ),
                     responseFields(
-                        fieldWithPath("status").description("Response status (SUCCESS, ERROR)"),
-                        fieldWithPath("message").description("Response message"),
-                        fieldWithPath("data").description("Response data (null for this endpoint)").optional(),
+                        *ApiResponseFieldSpecs.responseWithOptionalData(),
                     ),
                 ),
             )
@@ -107,58 +96,20 @@ class UserProfileUpdateApiTest {
                 .content("""{"reason": "서비스 불만족", "feedback": "앱 속도가 너무 느림"}"""),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "user-withdrawal",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestFields(
-                        fieldWithPath("reason").description("Reason for withdrawal"),
-                        fieldWithPath("feedback").description("Additional feedback").optional(),
+                        fieldWithPath("reason").description("탈퇴 사유"),
+                        fieldWithPath("feedback").description("추가 피드백").optional(),
                     ),
                     responseFields(
-                        fieldWithPath("status").description("Response status (SUCCESS, ERROR)"),
-                        fieldWithPath("message").description("Response message"),
-                        fieldWithPath("data").description("Response data (null for this endpoint)").optional(),
+                        *ApiResponseFieldSpecs.responseWithOptionalData(),
                     ),
                 ),
             )
-    }
-
-    @RestController
-    class MockUserProfileUpdateController {
-        @PostMapping("/api/users/profile")
-        fun updateProfile(
-            @RequestBody request: Map<String, Any?>,
-        ): Map<String, Any?> {
-            return mapOf(
-                "status" to "SUCCESS",
-                "message" to "프로필이 성공적으로 업데이트되었습니다.",
-                "data" to null,
-            )
-        }
-
-        @PostMapping("/api/users/device-token")
-        fun updateDeviceToken(
-            @RequestBody request: Map<String, Any>,
-        ): Map<String, Any?> {
-            return mapOf(
-                "status" to "SUCCESS",
-                "message" to "디바이스 토큰이 성공적으로 업데이트되었습니다.",
-                "data" to null,
-            )
-        }
-
-        @PostMapping("/api/users/withdraw")
-        fun withdraw(
-            @RequestBody request: Map<String, Any>,
-        ): Map<String, Any?> {
-            return mapOf(
-                "status" to "SUCCESS",
-                "message" to "회원 탈퇴가 성공적으로 처리되었습니다.",
-                "data" to null,
-            )
-        }
     }
 }

--- a/src/test/kotlin/com/flownews/api/user/api/UserQueryApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/user/api/UserQueryApiTest.kt
@@ -2,14 +2,13 @@ package com.flownews.api.user.api
 
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
 import com.flownews.testutils.ApiResponseFieldSpecs
-import com.flownews.testutils.MockCurrentUserArgumentResolver
+import com.flownews.testutils.MockMvcTestUtils
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.http.MediaType
 import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.restdocs.RestDocumentationExtension
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -19,10 +18,8 @@ import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 
-@ExtendWith(RestDocumentationExtension::class, MockitoExtension::class)
+@ExtendWith(RestDocumentationExtension::class)
 class UserQueryApiTest {
     private lateinit var mockMvc: MockMvc
 
@@ -30,16 +27,7 @@ class UserQueryApiTest {
     fun setUp(restDocumentation: RestDocumentationContextProvider) {
         val controller = UserQueryApi()
 
-        this.mockMvc =
-            MockMvcBuilders.standaloneSetup(controller)
-                .setCustomArgumentResolvers(MockCurrentUserArgumentResolver())
-                .apply<StandaloneMockMvcBuilder>(
-                    documentationConfiguration(restDocumentation)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()),
-                )
-                .build()
+        this.mockMvc = MockMvcTestUtils.createMockMvc(controller, restDocumentation)
     }
 
     @Test
@@ -49,7 +37,7 @@ class UserQueryApiTest {
                 .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."),
         )
             .andExpect(status().isOk)
-            .andExpect(content().contentType("application/json"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(
                 document(
                     "user-current-query",
@@ -57,12 +45,12 @@ class UserQueryApiTest {
                     preprocessResponse(prettyPrint()),
                     responseFields(
                         *ApiResponseFieldSpecs.responseWithData("Current user data"),
-                        fieldWithPath("data.id").description("User ID"),
-                        fieldWithPath("data.name").description("User name"),
-                        fieldWithPath("data.email").description("User email"),
-                        fieldWithPath("data.profileUrl").description("User profile image URL").optional(),
-                        fieldWithPath("data.role").description("User role (USER, ADMIN)"),
-                        fieldWithPath("data.isProfileComplete").description("Whether user profile is complete"),
+                        fieldWithPath("data.id").description("사용자 ID"),
+                        fieldWithPath("data.name").description("사용자 이름"),
+                        fieldWithPath("data.email").description("사용자 이메일"),
+                        fieldWithPath("data.profileUrl").description("사용자 프로필 이미지 URL").optional(),
+                        fieldWithPath("data.role").description("사용자 역할 (USER, ADMIN)"),
+                        fieldWithPath("data.isProfileComplete").description("사용자 프로필 완성 여부"),
                     ),
                 ),
             )

--- a/src/test/kotlin/com/flownews/api/user/api/UserQueryApiTest.kt
+++ b/src/test/kotlin/com/flownews/api/user/api/UserQueryApiTest.kt
@@ -50,7 +50,6 @@ class UserQueryApiTest {
                         fieldWithPath("data.email").description("사용자 이메일"),
                         fieldWithPath("data.profileUrl").description("사용자 프로필 이미지 URL").optional(),
                         fieldWithPath("data.role").description("사용자 역할 (USER, ADMIN)"),
-                        fieldWithPath("data.isProfileComplete").description("사용자 프로필 완성 여부"),
                     ),
                 ),
             )

--- a/src/test/kotlin/com/flownews/testutils/ApiResponseFieldSpecs.kt
+++ b/src/test/kotlin/com/flownews/testutils/ApiResponseFieldSpecs.kt
@@ -11,10 +11,10 @@ object ApiResponseFieldSpecs {
             fieldWithPath("data").description(dataDescription),
         )
 
-    fun responseWithOptionalData(dataDescription: String): Array<FieldDescriptor> =
+    fun responseWithOptionalData(): Array<FieldDescriptor> =
         arrayOf(
             fieldWithPath("code").description("응답 코드 (200, 400, 500 등)"),
             fieldWithPath("message").description("응답 메시지"),
-            fieldWithPath("data").description(dataDescription).optional(),
+            fieldWithPath("data").description("응답 데이터").optional(),
         )
 }

--- a/src/test/kotlin/com/flownews/testutils/MockCurrentUserArgumentResolver.kt
+++ b/src/test/kotlin/com/flownews/testutils/MockCurrentUserArgumentResolver.kt
@@ -29,8 +29,6 @@ class MockCurrentUserArgumentResolver : HandlerMethodArgumentResolver {
             profileUrl = null,
             role = Role.USER,
             deviceToken = "test-token",
-            birthDate = null,
-            gender = null,
         )
     }
 }

--- a/src/test/kotlin/com/flownews/testutils/MockCurrentUserArgumentResolver.kt
+++ b/src/test/kotlin/com/flownews/testutils/MockCurrentUserArgumentResolver.kt
@@ -1,5 +1,6 @@
 package com.flownews.testutils
 
+import com.flownews.api.common.api.CurrentUser
 import com.flownews.api.user.domain.User
 import com.flownews.api.user.domain.enums.Role
 import org.springframework.core.MethodParameter
@@ -10,7 +11,7 @@ import org.springframework.web.method.support.ModelAndViewContainer
 
 class MockCurrentUserArgumentResolver : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return parameter.hasParameterAnnotation(com.flownews.api.common.api.CurrentUser::class.java)
+        return parameter.hasParameterAnnotation(CurrentUser::class.java)
     }
 
     override fun resolveArgument(
@@ -18,7 +19,7 @@ class MockCurrentUserArgumentResolver : HandlerMethodArgumentResolver {
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?,
-    ): Any? {
+    ): User {
         return User(
             id = 1L,
             oauthId = "test-user-123",

--- a/src/test/kotlin/com/flownews/testutils/MockMvcTestUtils.kt
+++ b/src/test/kotlin/com/flownews/testutils/MockMvcTestUtils.kt
@@ -1,0 +1,37 @@
+package com.flownews.testutils
+
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+object MockMvcTestUtils {
+    fun createMockMvc(
+        controller: Any,
+        restDocumentation: RestDocumentationContextProvider,
+    ): MockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setCustomArgumentResolvers(MockCurrentUserArgumentResolver())
+            .apply<StandaloneMockMvcBuilder>(
+                documentationConfiguration(restDocumentation)
+                    .operationPreprocessors()
+                    .withRequestDefaults(prettyPrint())
+                    .withResponseDefaults(prettyPrint()),
+            )
+            .build()
+
+    fun createMockMvcWithoutAuth(
+        controller: Any,
+        restDocumentation: RestDocumentationContextProvider,
+    ): MockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .apply<StandaloneMockMvcBuilder>(
+                documentationConfiguration(restDocumentation)
+                    .operationPreprocessors()
+                    .withRequestDefaults(prettyPrint())
+                    .withResponseDefaults(prettyPrint()),
+            )
+            .build()
+}


### PR DESCRIPTION
## Summary
- MockMvc 테스트에서 mockito를 mockk로 변경하여 Kotlin과의 호환성 개선
- 불필요한 API 엔드포인트 제거 및 정리
- Spring REST Docs를 통한 API 문서 최신화
- 테스트 유틸리티 클래스 추가로 코드 중복 제거
- Claude Code용 Spring REST Docs 생성 에이전트 추가

## Changes
- mockito → mockk 마이그레이션으로 Kotlin 네이티브 테스트 환경 구축
- 사용되지 않는 API 엔드포인트 제거
- Spring REST Docs를 통한 API 문서 자동 생성 및 업데이트
- MockMvcTestUtils 유틸리티 클래스 추가로 테스트 코드 간소화
- Claude Code Spring REST Docs 생성 전용 에이전트 구성

## Test Plan
- [x] 기존 테스트 케이스들이 mockk로 정상 동작하는지 확인
- [x] API 문서가 올바르게 생성되는지 확인
- [x] 제거된 API가 더 이상 사용되지 않는지 확인
- [x] Claude 에이전트가 정상적으로 동작하는지 확인

Generated with [Claude Code](https://claude.ai/code)